### PR TITLE
Keep libpython *.a

### DIFF
--- a/docker/Dockerfile-x86_64
+++ b/docker/Dockerfile-x86_64
@@ -1,5 +1,5 @@
 # See docker/glibc/
-FROM quay.io/pypa/manylinux2010_centos-6-no-vsyscall
+FROM centos:6
 LABEL maintainer="The ManyLinux project"
 
 ENV AUDITWHEEL_ARCH x86_64

--- a/docker/build_scripts/build.sh
+++ b/docker/build_scripts/build.sh
@@ -184,7 +184,7 @@ yum -y clean all > /dev/null 2>&1
 yum list installed
 
 # we don't need libpython*.a, and they're many megabytes
-find /opt/_internal -name '*.a' -print0 | xargs -0 rm -f
+# find /opt/_internal -name '*.a' -print0 | xargs -0 rm -f
 
 # Strip what we can -- and ignore errors, because this just attempts to strip
 # *everything*, including non-ELF files:

--- a/docker/build_scripts/build_env.sh
+++ b/docker/build_scripts/build_env.sh
@@ -2,7 +2,7 @@
 
 PYTHON_DOWNLOAD_URL=https://www.python.org/ftp/python
 # of the form <maj>.<min>.<rev> or <maj>.<min>.<rev>rc<n>
-CPYTHON_VERSIONS="2.7.17 3.4.10 3.5.9 3.6.10 3.7.6 3.8.1"
+CPYTHON_VERSIONS="3.5.9 3.6.10 3.7.6 3.8.1"
 
 # openssl version to build, with expected sha256 hash of .tar.gz
 # archive.


### PR DESCRIPTION
cc @JohanMabille 

To build the image locally:

```bash
cd docker/
docker build -f Dockerfile-x86_64 -t manylinux_2010_x86_64-python-dev .
```

Pushed to https://hub.docker.com/r/quantstack/manylinux_2010_x86_64-python-dev using:

```bash
docker login
docker tag manylinux_2010_x86_64-python-dev:latest quantstack/manylinux_2010_x86_64-python-dev:latest
docker push quantstack/manylinux_2010_x86_64-python-dev:latest
```